### PR TITLE
:sparkles: Remove classes by category

### DIFF
--- a/fbot_recognition/config/yolov8_object_recognition.yaml
+++ b/fbot_recognition/config/yolov8_object_recognition.yaml
@@ -22,11 +22,7 @@ yolov8_recognition:
       object_recognition:
         topic: /fbot_vision/fr/object_recognition
         qos_profile: 10
-      
-      people_detection:
-        topic: /fbot_vision/fr/people_detection
-        qos_profile: 10
 
       debug:
-        topic: /fbot_vision/fr/debug
+        topic: /fbot_vision/fr/object_debug
         qos_profile: 10

--- a/fbot_recognition/config/yolov8_object_recognition.yaml
+++ b/fbot_recognition/config/yolov8_object_recognition.yaml
@@ -2,22 +2,6 @@ yolov8_recognition:
   ros__parameters:
 
     threshold: 0.6
-
-    classes_by_category: '{"Drinks": ["person", "bottle", "wine glass", "cup"],
-                          "Cleaning supplies": ["scissors", "toothbrush", "hair drier"],
-                          "Pantry items": ["banana", "apple", "orange", "sandwich", "broccoli", "carrot", "hot dog", "pizza", "donut", "cake", "fork", "knife", "spoon", "bowl"],
-                          "Fruits": ["banana", "apple", "orange"],
-                          "Snacks": ["hot dog", "pizza", "donut", "cake", "frisbee", "skateboard"],
-                          "Vehicles": ["bicycle", "car", "motorcycle", "airplane", "bus", "train", "truck", "boat"],
-                          "Traffic items": ["traffic light", "fire hydrant", "stop sign", "parking meter"],
-                          "Furniture": ["bench", "chair", "couch", "potted plant", "bed", "dining table", "tv", "refrigerator", "microwave", "oven", "toaster", "sink", "stove"],
-                          "Electronics": ["laptop", "mouse", "remote", "keyboard", "cell phone"],
-                          "Animals": ["bird", "cat", "dog", "horse", "sheep", "cow", "elephant", "bear", "zebra", "giraffe"],
-                          "Personal items": ["backpack", "umbrella", "handbag", "tie", "suitcase"],
-                          "Sports": ["frisbee", "skis", "snowboard", "sports ball", "kite", "baseball bat", "baseball glove", "skateboard", "surfboard", "tennis racket"],
-                          "Tools": ["scissors", "teddy bear", "hair drier", "toothbrush"],
-                          "Office items": ["book", "clock", "vase", "scissors", "teddy bear"],
-                          "Others": ["cell phone", "microwave", "oven", "toaster", "sink", "refrigerator"]}'
       
     max_sizes:
         - [0.5, 0.5, 0.5]

--- a/fbot_recognition/fbot_recognition/yolov8_recognition/yolov8_recognition.py
+++ b/fbot_recognition/fbot_recognition/yolov8_recognition/yolov8_recognition.py
@@ -38,7 +38,6 @@ class YoloV8Recognition(BaseRecognition):
         self.debugPublisher = self.create_publisher(Image, self.debugImageTopic, qos_profile=self.debugQosProfile)
         self.markerPublisher = self.create_publisher(MarkerArray, 'pub/markers', qos_profile=self.debugQosProfile)
         self.objectRecognitionPublisher = self.create_publisher(Detection3DArray, self.objectRecognitionTopic, qos_profile=self.objectRecognitionQosProfile)
-        self.peopleDetectionPublisher = self.create_publisher(Detection3DArray, self.peopleDetectionTopic, qos_profile=self.peopleDetectionQosProfile)
         super().initRosComm(callbackObject=self)
 
     def loadModel(self) -> None: 
@@ -206,8 +205,6 @@ class YoloV8Recognition(BaseRecognition):
         self.declare_parameter("publishers.debug.qos_profile", 1)
         self.declare_parameter("publishers.object_recognition.topic", "/fbot_vision/fr/object_recognition")
         self.declare_parameter("publishers.object_recognition.qos_profile", 1)
-        self.declare_parameter("publishers.people_detection.topic", "/fbot_vision/fr/people_detection")
-        self.declare_parameter("publishers.people_detection.qos_profile", 1)
         self.declare_parameter("threshold", 0.5)
         self.declare_parameter("model_file", "yolov8n.pt")
         self.declare_parameter("max_sizes", [0.05, 0.05, 0.05])
@@ -218,8 +215,6 @@ class YoloV8Recognition(BaseRecognition):
         self.debugQosProfile = self.get_parameter("publishers.debug.qos_profile").value
         self.objectRecognitionTopic = self.get_parameter("publishers.object_recognition.topic").value
         self.objectRecognitionQosProfile = self.get_parameter("publishers.object_recognition.qos_profile").value
-        self.peopleDetectionTopic = self.get_parameter("publishers.people_detection.topic").value
-        self.peopleDetectionQosProfile = self.get_parameter("publishers.people_detection.qos_profile").value
         self.threshold = self.get_parameter("threshold").value
         self.get_logger().info(f"Threshold: {self.threshold}")
         self.modelFile = get_package_share_directory('fbot_recognition') + "/weights/" + self.get_parameter("model_file").value

--- a/fbot_recognition/fbot_recognition/yolov8_recognition/yolov8_recognition.py
+++ b/fbot_recognition/fbot_recognition/yolov8_recognition/yolov8_recognition.py
@@ -125,7 +125,7 @@ class YoloV8Recognition(BaseRecognition):
         if '/' in label:
             detection3d.label = label
         else:
-            detection3d.label = f"none/{label}"
+            detection3d.label = f"none/{label}" if label[0].islower() else f"None/{label}"
 
         detection3d.bbox2d = copy.deepcopy(bb2d)
         detection3d.bbox3d = bb3d

--- a/fbot_recognition/fbot_recognition/yolov8_recognition/yolov8_recognition.py
+++ b/fbot_recognition/fbot_recognition/yolov8_recognition/yolov8_recognition.py
@@ -26,7 +26,7 @@ from ament_index_python.packages import get_package_share_directory
 #TODO: Need one declare parameters and one read parameters functions
 
 class YoloV8Recognition(BaseRecognition):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(nodeName='yolov8_recognition')
 
         self.declareParameters()
@@ -34,25 +34,25 @@ class YoloV8Recognition(BaseRecognition):
         self.loadModel()
         self.initRosComm()
 
-    def initRosComm(self):
+    def initRosComm(self) -> None:
         self.debugPublisher = self.create_publisher(Image, self.debugImageTopic, qos_profile=self.debugQosProfile)
         self.markerPublisher = self.create_publisher(MarkerArray, 'pub/markers', qos_profile=self.debugQosProfile)
         self.objectRecognitionPublisher = self.create_publisher(Detection3DArray, self.objectRecognitionTopic, qos_profile=self.objectRecognitionQosProfile)
         self.peopleDetectionPublisher = self.create_publisher(Detection3DArray, self.peopleDetectionTopic, qos_profile=self.peopleDetectionQosProfile)
         super().initRosComm(callbackObject=self)
 
-    def loadModel(self): 
+    def loadModel(self) -> None: 
         self.get_logger().info("=> Loading model")
         self.model = YOLO(self.modelFile)
         self.model.conf = self.threshold
         self.get_logger().info("=> Loaded")
 
-    def unLoadModel(self):
+    def unLoadModel(self) -> None:
         del self.model
         torch.cuda.empty_cache()
         self.model = None
 
-    def callback(self, depthMsg: Image, imageMsg: Image, cameraInfoMsg: CameraInfo):
+    def callback(self, depthMsg: Image, imageMsg: Image, cameraInfoMsg: CameraInfo) -> None:
 
         self.get_logger().info("=> Entering callback ")
 
@@ -115,7 +115,7 @@ class YoloV8Recognition(BaseRecognition):
 
         self.publishMarkers(detection3DArray.detections)
 
-    def createDetection3d(self, bb2d: BoundingBox2D, bb3d: BoundingBox3D , score: float, detectionHeader: Header, label: str):
+    def createDetection3d(self, bb2d: BoundingBox2D, bb3d: BoundingBox3D , score: float, detectionHeader: Header, label: str) -> Detection3D:
         detection3d = Detection3D()
         detection3d.header = detectionHeader
         detection3d.id = 0
@@ -133,7 +133,7 @@ class YoloV8Recognition(BaseRecognition):
         return detection3d
 
 
-    def publishMarkers(self, descriptions3d):
+    def publishMarkers(self, descriptions3d) -> None:
         markers = MarkerArray()
         duration = Duration()
         duration.sec = 2
@@ -201,7 +201,7 @@ class YoloV8Recognition(BaseRecognition):
         
         self.markerPublisher.publish(markers)
 
-    def declareParameters(self):
+    def declareParameters(self) -> None:
         self.declare_parameter("publishers.debug.topic", "/fbot_vision/fr/debug")
         self.declare_parameter("publishers.debug.qos_profile", 1)
         self.declare_parameter("publishers.object_recognition.topic", "/fbot_vision/fr/object_recognition")
@@ -213,7 +213,7 @@ class YoloV8Recognition(BaseRecognition):
         self.declare_parameter("max_sizes", [0.05, 0.05, 0.05])
         super().declareParameters()
 
-    def readParameters(self):
+    def readParameters(self) -> None:
         self.debugImageTopic = self.get_parameter("publishers.debug.topic").value
         self.debugQosProfile = self.get_parameter("publishers.debug.qos_profile").value
         self.objectRecognitionTopic = self.get_parameter("publishers.object_recognition.topic").value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+image2world
+open3d
+ultralytics
+reidmanager


### PR DESCRIPTION
This PR does a feel different things.

- Remove classes_by_category param. From now on the category and label must come directly from the yolo weights. If the label does not contain "/" it will turn it into f"none/{label}"
- Changed debug topic to "object_debug"
- Removed unused people detection topics
- Added type hints
- Added a requirements.txt 